### PR TITLE
Refactor MyHome config flow and options handling

### DIFF
--- a/custom_components/myhome/config_flow.py
+++ b/custom_components/myhome/config_flow.py
@@ -79,7 +79,7 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return MyhomeOptionsFlowHandler(config_entry)
+        return MyhomeOptionsFlowHandler()
 
     def __init__(self):
         """Initialize the MyHome flow."""
@@ -374,11 +374,17 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
 class MyhomeOptionsFlowHandler(OptionsFlow):
     """Handle MyHome options."""
 
-    def __init__(self, config_entry):
+    def __init__(self):
         """Initialize MyHome options flow."""
-        self.config_entry = config_entry
-        self.options = dict(config_entry.options)
-        self.data = dict(config_entry.data)
+        self.options = {}
+        self.data = {}
+
+    async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument
+        """Manage the MyHome options."""
+        if not self.options:
+            self.options = dict(self.config_entry.options)
+        if not self.data:
+            self.data = dict(self.config_entry.data)
         if CONF_WORKER_COUNT not in self.options:
             self.options[CONF_WORKER_COUNT] = 1
         if CONF_FILE_PATH not in self.options:
@@ -386,8 +392,6 @@ class MyhomeOptionsFlowHandler(OptionsFlow):
         if CONF_GENERATE_EVENTS not in self.options:
             self.options[CONF_GENERATE_EVENTS] = False
 
-    async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument
-        """Manage the MyHome options."""
         return await self.async_step_user()
 
     async def async_step_user(self, user_input=None, errors={}):  # pylint: disable=dangerous-default-value
@@ -447,3 +451,4 @@ class MyhomeOptionsFlowHandler(OptionsFlow):
             ),
             errors=errors,
         )
+


### PR DESCRIPTION
Fixing the error related to config_entry after the latest HA update.

The error can be tested by clicking:

<img width="1037" height="251" alt="Screenshot 2025-12-10 at 17 21 01" src="https://github.com/user-attachments/assets/541de490-7fa8-466c-a97a-fc6798a4023e" />
